### PR TITLE
Simplify variable names and remove comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(Da_Vinci_controller
     hardware_adc
 )
 
-# USB stdio on, UART off (tweak if needed)
 pico_enable_stdio_usb(Da_Vinci_controller 1)
 pico_enable_stdio_uart(Da_Vinci_controller 0)
 

--- a/include/pot.hpp
+++ b/include/pot.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "pico/stdlib.h"
 
-struct PotConfig { uint adc_gpio = 26; };
-void     pot_init(const PotConfig& cfg);
-uint16_t pot_read_raw12(); // 0..4095
+struct PotConfig { uint pin = 26; };
+void pot_init(const PotConfig& cfg);
+uint16_t pot_read_raw12();
 

--- a/include/servo.hpp
+++ b/include/servo.hpp
@@ -4,7 +4,7 @@
 
 class Servo {
 public:
-    Servo() : gpio_pin_(255), slice_num_(0), top_(0), attached_(false), period_us_(20000.0f) {}
+    Servo() : pin(255), slice(0), top(0), attached(false), period(20000.0f) {}
 
     bool attach(uint gpio_pin, float freq_hz = 50.0f, float clkdiv = 64.0f);
     void detach();
@@ -14,13 +14,13 @@ public:
     void center();
 
 private:
-    uint gpio_pin_;
-    uint slice_num_;
-    uint32_t top_;
-    bool attached_;
-    float period_us_;
+    uint pin;
+    uint slice;
+    uint32_t top;
+    bool attached;
+    float period;
 
-    static constexpr uint16_t kMinUs = 500;   // MG996R safe range
-    static constexpr uint16_t kMaxUs = 2500;
+    static constexpr uint16_t min_us = 500;
+    static constexpr uint16_t max_us = 2500;
 };
 

--- a/pico_sdk_import.cmake
+++ b/pico_sdk_import.cmake
@@ -1,7 +1,4 @@
-# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
 
-# This can be dropped into an external project to help locate this SDK
-# It should be include()ed prior to project()
 
 if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
     set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
@@ -29,7 +26,6 @@ if (NOT PICO_SDK_PATH)
         if (PICO_SDK_FETCH_FROM_GIT_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
-        # GIT_SUBMODULES_RECURSE was added in 3.17
         if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
             FetchContent_Declare(
                     pico_sdk

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,63 +3,53 @@
 #include "servo.hpp"
 #include "pot.hpp"
 
-// ---------- USER SETTINGS ----------
-// Set these to the ACTUAL raw values at each end (see serial prints)
-static constexpr uint16_t RAW_MIN = 10;   // <-- replace after measuring
-static constexpr uint16_t RAW_MAX = 4085;  // <-- replace after measuring
+static constexpr uint16_t min_raw = 10;
+static constexpr uint16_t max_raw = 4085;
+static constexpr float servo_min = 0.0f;
+static constexpr float servo_max = 180.0f;
+static constexpr bool invert_pot = false;
 
-// Servo travel (use full 0..180 unless you need to limit it)
-static constexpr float SERVO_MIN_DEG = 0.0f;
-static constexpr float SERVO_MAX_DEG = 180.0f;
-
-// Invert slider direction if needed
-static constexpr bool INVERT_POT = false;
-// -----------------------------------
-
-static inline float clamp01(float x) { return x < 0.f ? 0.f : (x > 1.f ? 1.f : x); }
+static inline float clamp(float x) { return x < 0.f ? 0.f : (x > 1.f ? 1.f : x); }
 
 int main() {
     stdio_init_all();
     sleep_ms(300);
 
-    // Pot on GPIO26 (ADC0) by default
-    PotConfig pc;
-    pc.adc_gpio = 26;
-    pot_init(pc);
+    PotConfig cfg;
+    cfg.pin = 26;
+    pot_init(cfg);
 
-    // Servo on GP15
-    const uint SERVO_GPIO = 15;
-    Servo s;
-    s.attach(SERVO_GPIO);
+    const uint servo_pin = 15;
+    Servo servo;
+    servo.attach(servo_pin);
 
-    const float raw_span = (float)RAW_MAX - (float)RAW_MIN;
-    const float deg_span = SERVO_MAX_DEG - SERVO_MIN_DEG;
-    if (raw_span <= 0.0f) {
-        printf("ERROR: RAW_MAX must be > RAW_MIN.\n");
+    const float raw_range = (float)max_raw - (float)min_raw;
+    const float deg_range = servo_max - servo_min;
+    if (raw_range <= 0.0f) {
+        printf("ERROR: max_raw must be > min_raw.\n");
         while (true) tight_loop_contents();
     }
 
     printf("Linear map raw %u..%u -> %.1f..%.1f deg (invert=%s)\n",
-           RAW_MIN, RAW_MAX, SERVO_MIN_DEG, SERVO_MAX_DEG, INVERT_POT ? "yes" : "no");
+           min_raw, max_raw, servo_min, servo_max, invert_pot ? "yes" : "no");
 
     while (true) {
-        uint16_t raw = pot_read_raw12();           // 0..4095
-        float x = ((float)raw - (float)RAW_MIN) / raw_span;
-        x = clamp01(x);
-        if (INVERT_POT) x = 1.0f - x;
+        uint16_t raw = pot_read_raw12();
+        float x = ((float)raw - (float)min_raw) / raw_range;
+        x = clamp(x);
+        if (invert_pot) x = 1.0f - x;
 
-        float angle = SERVO_MIN_DEG + x * deg_span; // strict linear
-        s.writeAngle(angle);
+        float angle = servo_min + x * deg_range;
+        servo.writeAngle(angle);
 
-        // Debug ~4 Hz
-        static uint32_t tprint = 0;
-        uint32_t now = to_ms_since_boot(get_absolute_time());
-        if (now - tprint > 250) {
+        static uint32_t last_print = 0;
+        uint32_t now_ms = to_ms_since_boot(get_absolute_time());
+        if (now_ms - last_print > 250) {
             printf("raw=%4u  x=%.3f  angle=%.1f\n", raw, x, angle);
-            tprint = now;
+            last_print = now_ms;
         }
 
-        sleep_us(1000); // fast loop, no filtering
+        sleep_us(1000);
     }
 }
 

--- a/src/pot.cpp
+++ b/src/pot.cpp
@@ -1,15 +1,15 @@
 #include "pot.hpp"
 #include "hardware/adc.h"
 
-static bool s_inited = false;
+static bool initialized = false;
 
 void pot_init(const PotConfig& cfg) {
-    if (s_inited) return;
-    uint input = (cfg.adc_gpio == 26) ? 0 : (cfg.adc_gpio == 27) ? 1 : 2;
+    if (initialized) return;
+    uint channel = (cfg.pin == 26) ? 0 : (cfg.pin == 27) ? 1 : 2;
     adc_init();
-    adc_gpio_init(cfg.adc_gpio);
-    adc_select_input(input);
-    s_inited = true;
+    adc_gpio_init(cfg.pin);
+    adc_select_input(channel);
+    initialized = true;
 }
 
 uint16_t pot_read_raw12() { return (uint16_t)adc_read(); }

--- a/src/servo.cpp
+++ b/src/servo.cpp
@@ -1,53 +1,52 @@
 #include "servo.hpp"
 
 bool Servo::attach(uint gpio_pin, float freq_hz, float clkdiv) {
-    if (attached_) return true;
+    if (attached) return true;
 
-    gpio_pin_ = gpio_pin;
-    gpio_set_function(gpio_pin_, GPIO_FUNC_PWM);
+    pin = gpio_pin;
+    gpio_set_function(pin, GPIO_FUNC_PWM);
 
-    slice_num_ = pwm_gpio_to_slice_num(gpio_pin_);
+    slice = pwm_gpio_to_slice_num(pin);
 
-    // PWM freq = 125e6 / (clkdiv * (TOP + 1))
-    float f_sys = 125000000.0f;
-    top_ = (uint32_t)((f_sys / (clkdiv * freq_hz)) - 1.0f);
+    float sys_freq = 125000000.0f;
+    top = (uint32_t)((sys_freq / (clkdiv * freq_hz)) - 1.0f);
 
     pwm_config cfg = pwm_get_default_config();
     pwm_config_set_clkdiv(&cfg, clkdiv);
-    pwm_config_set_wrap(&cfg, top_);
-    pwm_init(slice_num_, &cfg, true);
+    pwm_config_set_wrap(&cfg, top);
+    pwm_init(slice, &cfg, true);
 
-    period_us_ = 1000000.0f / freq_hz; // e.g., 50 Hz -> 20000 µs
-    attached_ = true;
+    period = 1000000.0f / freq_hz;
+    attached = true;
     center();
     return true;
 }
 
 void Servo::detach() {
-    if (!attached_) return;
-    pwm_set_enabled(slice_num_, false);
-    attached_ = false;
+    if (!attached) return;
+    pwm_set_enabled(slice, false);
+    attached = false;
 }
 
 void Servo::writeMicroseconds(uint16_t us) {
-    if (!attached_) return;
-    if (us < kMinUs) us = kMinUs;
-    if (us > kMaxUs) us = kMaxUs;
+    if (!attached) return;
+    if (us < min_us) us = min_us;
+    if (us > max_us) us = max_us;
 
-    uint32_t level = (uint32_t)(((uint64_t)us * (top_ + 1)) / (uint32_t)period_us_);
-    pwm_set_gpio_level(gpio_pin_, level);
+    uint32_t level = (uint32_t)(((uint64_t)us * (top + 1)) / (uint32_t)period);
+    pwm_set_gpio_level(pin, level);
 }
 
 void Servo::writeAngle(float degrees) {
     if (degrees < 0.0f) degrees = 0.0f;
     if (degrees > 180.0f) degrees = 180.0f;
 
-    float span = (float)(kMaxUs - kMinUs);
-    uint16_t us = (uint16_t)(kMinUs + (degrees / 180.0f) * span);
+    float span = (float)(max_us - min_us);
+    uint16_t us = (uint16_t)(min_us + (degrees / 180.0f) * span);
     writeMicroseconds(us);
 }
 
 void Servo::center() {
-    writeMicroseconds((kMinUs + kMaxUs) / 2);
+    writeMicroseconds((min_us + max_us) / 2);
 }
 


### PR DESCRIPTION
## Summary
- remove comments and adopt simpler variable names across source files
- streamline build scripts by stripping comments

## Testing
- `cmake -S . -B build` *(fails: SDK location was not specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e72837dd88320acdb4843e8254053