### PR TITLE
Eliminate floating-point math in servo control

### DIFF
--- a/include/servo.hpp
+++ b/include/servo.hpp
@@ -4,13 +4,13 @@
 
 class Servo {
 public:
-    Servo() : pin(255), slice(0), top(0), attached(false), period(20000.0f) {}
+    Servo() : pin(255), slice(0), top(0), attached(false), period(20000) {}
 
-    bool attach(uint gpio_pin, float freq_hz = 50.0f, float clkdiv = 64.0f);
+    bool attach(uint gpio_pin, uint32_t freq_hz = 50, uint8_t clkdiv = 64);
     void detach();
 
     void writeMicroseconds(uint16_t us);
-    void writeAngle(float degrees);
+    void writeAngle(uint16_t degrees);
     void center();
 
 private:
@@ -18,7 +18,7 @@ private:
     uint slice;
     uint32_t top;
     bool attached;
-    float period;
+    uint32_t period; // microseconds
 
     static constexpr uint16_t min_us = 500;
     static constexpr uint16_t max_us = 2500;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,11 +5,9 @@
 
 static constexpr uint16_t min_raw = 10;
 static constexpr uint16_t max_raw = 4085;
-static constexpr float servo_min = 0.0f;
-static constexpr float servo_max = 180.0f;
+static constexpr uint16_t servo_min = 0;
+static constexpr uint16_t servo_max = 180;
 static constexpr bool invert_pot = false;
-
-static inline float clamp(float x) { return x < 0.f ? 0.f : (x > 1.f ? 1.f : x); }
 
 int main() {
     stdio_init_all();
@@ -23,29 +21,32 @@ int main() {
     Servo servo;
     servo.attach(servo_pin);
 
-    const float raw_range = (float)max_raw - (float)min_raw;
-    const float deg_range = servo_max - servo_min;
-    if (raw_range <= 0.0f) {
+    const uint16_t raw_range = max_raw - min_raw;
+    const uint16_t deg_range = servo_max - servo_min;
+    if (raw_range == 0) {
         printf("ERROR: max_raw must be > min_raw.\n");
         while (true) tight_loop_contents();
     }
 
-    printf("Linear map raw %u..%u -> %.1f..%.1f deg (invert=%s)\n",
+    printf("Linear map raw %u..%u -> %u..%u deg (invert=%s)\n",
            min_raw, max_raw, servo_min, servo_max, invert_pot ? "yes" : "no");
 
     while (true) {
         uint16_t raw = pot_read_raw12();
-        float x = ((float)raw - (float)min_raw) / raw_range;
-        x = clamp(x);
-        if (invert_pot) x = 1.0f - x;
+        uint16_t value = raw;
+        if (value < min_raw) value = min_raw;
+        if (value > max_raw) value = max_raw;
+        uint16_t delta = value - min_raw;
+        if (invert_pot) delta = raw_range - delta;
 
-        float angle = servo_min + x * deg_range;
+        uint16_t angle = servo_min + ((uint32_t)delta * deg_range) / raw_range;
         servo.writeAngle(angle);
 
         static uint32_t last_print = 0;
         uint32_t now_ms = to_ms_since_boot(get_absolute_time());
         if (now_ms - last_print > 250) {
-            printf("raw=%4u  x=%.3f  angle=%.1f\n", raw, x, angle);
+            uint16_t percent = ((uint32_t)delta * 100) / raw_range;
+            printf("raw=%4u  angle=%3u (%3u%%)\n", raw, angle, percent);
             last_print = now_ms;
         }
 

--- a/src/servo.cpp
+++ b/src/servo.cpp
@@ -1,6 +1,6 @@
 #include "servo.hpp"
 
-bool Servo::attach(uint gpio_pin, float freq_hz, float clkdiv) {
+bool Servo::attach(uint gpio_pin, uint32_t freq_hz, uint8_t clkdiv) {
     if (attached) return true;
 
     pin = gpio_pin;
@@ -8,15 +8,15 @@ bool Servo::attach(uint gpio_pin, float freq_hz, float clkdiv) {
 
     slice = pwm_gpio_to_slice_num(pin);
 
-    float sys_freq = 125000000.0f;
-    top = (uint32_t)((sys_freq / (clkdiv * freq_hz)) - 1.0f);
+    uint32_t sys_freq = 125000000;
+    top = (sys_freq / (clkdiv * freq_hz)) - 1;
 
     pwm_config cfg = pwm_get_default_config();
-    pwm_config_set_clkdiv(&cfg, clkdiv);
+    pwm_config_set_clkdiv_int_frac(&cfg, clkdiv, 0);
     pwm_config_set_wrap(&cfg, top);
     pwm_init(slice, &cfg, true);
 
-    period = 1000000.0f / freq_hz;
+    period = 1000000 / freq_hz;
     attached = true;
     center();
     return true;
@@ -37,12 +37,11 @@ void Servo::writeMicroseconds(uint16_t us) {
     pwm_set_gpio_level(pin, level);
 }
 
-void Servo::writeAngle(float degrees) {
-    if (degrees < 0.0f) degrees = 0.0f;
-    if (degrees > 180.0f) degrees = 180.0f;
+void Servo::writeAngle(uint16_t degrees) {
+    if (degrees > 180) degrees = 180;
 
-    float span = (float)(max_us - min_us);
-    uint16_t us = (uint16_t)(min_us + (degrees / 180.0f) * span);
+    uint16_t span = max_us - min_us;
+    uint16_t us = min_us + (span * degrees) / 180;
     writeMicroseconds(us);
 }
 


### PR DESCRIPTION
## Summary
- Replace float-based servo configuration with integer frequency and clock divider
- Map potentiometer readings to servo angles using integer arithmetic only

## Testing
- `cmake .. && make` *(fails: SDK location was not specified)*

------
https://chatgpt.com/codex/tasks/task_e_689e750d5ce483208221d82242202489